### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+4] - June 21, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.3+3] - June, 7, 2022
 
 * Automated dependency updates
@@ -6,6 +11,7 @@
 ## [1.0.3+2] - May, 31, 2022
 
 * Automated dependency updates
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'grpc_pubsub'
 description: 'Wrapper client around the gRPC based APIs for Google Pub/Sub that supports streaming and retries.'
-version: '1.0.3+3'
+version: '1.0.3+4'
 homepage: 'https://github.com/peiffer-innovations/grpc_pubsub'
 
 environment: 
@@ -12,10 +12,10 @@ dependencies:
   grpc_protobuf_convert: '^2.0.0+3'
   logging: '^1.0.2'
   meta: '^1.7.0'
-  protobuf: '^2.0.1'
+  protobuf: '^2.1.0'
 
 dev_dependencies: 
-  test: '^1.21.1'
+  test: '^1.21.2'
 
 ignore_updates: 
   - 'async'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `protobuf`: 2.0.1 --> 2.1.0

dev_dependencies:
  * `test`: 1.21.1 --> 1.21.2


Analysis Successful

