### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+9] - December 13, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.0+8] - November 8, 2022
 
 * Automated dependency updates
@@ -41,6 +46,7 @@
 ## [1.0.0] - July 1st, 2022
 
 * Initial Release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'rest_pubsub'
 description: 'REST based client for performing Pub/Sub operations within Dart and Flutter.'
-version: '1.0.0+8'
+version: '1.0.0+9'
 homepage: 'https://github.com/peiffer-innovations/rest_pubsub'
 
-environment:
+environment: 
   sdk: '>=2.18.0 <3.0.0'
 
-dependencies:
+dependencies: 
   googleapis: '^9.2.0'
   googleapis_auth: '^1.3.1'
   logging: '^1.1.0'
   meta: '^1.7.0'
 
-dev_dependencies:
-  test: '^1.22.0'
+dev_dependencies: 
+  test: '^1.22.1'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dev_dependencies:
  * `test`: 1.22.0 --> 1.22.1


Analysis Successful

